### PR TITLE
Return empty string for anonymous funciton

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,8 @@ const noop6 = require("noop6");
     try {
         Object.defineProperty(Function.prototype, NAME_FIELD, {
             get: function () {
-                var name = this.toString().trim().match(/^function\s*([^\s(]+)/)[1];
+                var nameMatch = this.toString().trim().match(/^function\s*([^\s(]+)/);
+                var name = nameMatch ? nameMatch[1] : "";
                 Object.defineProperty(this, NAME_FIELD, { value: name });
                 return name;
             }


### PR DESCRIPTION
Anonymous functions should have a name of empty string. Currently this polyfill throws an exception when `(function () {}).name` is executed.